### PR TITLE
fix: remove unused mode argument from generate_embed_url call

### DIFF
--- a/app/services/maps_service.py
+++ b/app/services/maps_service.py
@@ -196,7 +196,7 @@ class MapsService:
             )
 
         # Generate full route URLs
-        full_route_embed = self.generate_embed_url(places, mode="directions")
+        full_route_embed = self.generate_embed_url(places)
         full_route_link = self.generate_full_route_link(places, travel_mode)
 
         map_data = MapData(


### PR DESCRIPTION
## Problem

`generate_embed_url()` no longer accepts `mode` parameter (removed in previous refactoring), but `generate_map_data()` was still passing `mode='directions'`.

This caused a runtime `TypeError`:
```
TypeError: MapsService.generate_embed_url() got an unexpected keyword argument 'mode'
```

## Solution

✅ Removed `mode='directions'` argument from line 199 in `maps_service.py`

The function generates correct URLs without explicit mode parameter.

## Testing

- ✅ Docker build successful
- ✅ Full API request flow works
- ✅ Map data generation verified
- ✅ All pre-commit hooks passed

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change