### PR TITLE
fix: add Vercel frontend URL to CORS allowed origins

### DIFF
--- a/app/core/config/environments.py
+++ b/app/core/config/environments.py
@@ -101,7 +101,13 @@ class ProductionConfig(BaseConfig):
     log_level: str = "WARNING"
 
     # Strict CORS for production
-    cors_origins: list[str] = Field(default=["https://cityhelper.ai", "https://www.cityhelper.ai"])
+    cors_origins: list[str] = Field(
+        default=[
+            "https://cityhelper.ai",
+            "https://www.cityhelper.ai",
+            "https://city-helper-ai.vercel.app",
+        ]
+    )
 
     # Production delays
     auth_delay: float = 0.5


### PR DESCRIPTION
Adds https://city-helper-ai.vercel.app to the list of allowed CORS origins for production environment to enable frontend-backend communication.